### PR TITLE
Allow String#%

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -138,6 +138,7 @@ Style/EmptyLinesAroundModuleBody:
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 Style/FormatString:
   Enabled: true
+  EnforcedStyle: percent
 
 # Configuration parameters: MinBodyLength.
 Style/GuardClause:


### PR DESCRIPTION
I like to use:

```
"This %s a string, with %d placeholders. %s with it" % ["is", 3, "DEAL"]
```

IMHO this is a reasonable alternative to:

```
"This #{"is"} a string, with #{3} placeholders. #{"DEAL"} with it"
```

So this change allows for it.
