### PR TITLE
Prefer lambda.call over lambda.()

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -168,7 +168,10 @@ Style/IndentationWidth:
 # Cop supports --auto-correct.
 # Configuration parameters: SupportedStyles.
 Style/LambdaCall:
-  EnforcedStyle: braces
+  EnforcedStyle: call
+  Description: 'Use lambda.call(...) instead of lambda.(...).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
+  Enabled: true
 
 # Cop supports --auto-correct.
 Style/LeadingCommentSpace:


### PR DESCRIPTION
``` ruby
lambda.call("thing")
```

vs

``` ruby
lambda.("thing")
```

Me after reading the first notation:

![how it should be](http://media.giphy.com/media/FOY3t4BBe3xBu/giphy.gif)

Reaction after reading the second one:

![Not like this](http://h-4.abload.de/img/notlikethis3rxq.gif)