### PR TITLE
Use leading . instead of trailing .

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -394,3 +394,9 @@ Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: false
+
+Style/DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
+  Enabled: true
+  EnforcedStyle: leading


### PR DESCRIPTION
``` ruby
reprazent.fetch(:bird)
  .fetch(:name)
```

vs 

``` ruby
reprazent.fetch(:bird).
  fetch(:name)
```

The leading dots make it easier to spot a missing one. (The trailing one doesn't force the reader to look for a second line, discussed on chat with @bramj on chat, leading dots ftw).