### PR TITLE
Remove some generated files from checking

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -1,5 +1,7 @@
 AllCops:
   Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
     - db/schema.rb
 
 # Configuration parameters: AllowSafeAssignment.


### PR DESCRIPTION
Some of these generated files (like db/schema.rb or config/devise.rb)
are generated by gems or migrations and don't follow our conventions.

Maybe we shouldn't let our hound bark for those.

After talking to @bramj this seemed like the way to go.

Any opinions @pjaspers @10tolewis ?